### PR TITLE
disable recall after first window

### DIFF
--- a/recall.js
+++ b/recall.js
@@ -25,7 +25,7 @@
 
 
   var recall = lt.user_plugins.recall || {};
-  if(recall.initialized) {
+  if(recall.initialized || (lt.objs.app.window_number() != 0)) {
     return recall;
   }
   lt.user_plugins.recall = recall;


### PR DESCRIPTION
When I open a second window, my files that were already recalled in the first window are recalled again. I'd like to disable this since I like a new window to start out as a clean state for a new workspace. Would you like this behavior? If not, could we add it as an option? Fwiw, the first window is 0, second is 1, etc.

Thanks for the plugin!
